### PR TITLE
feat(responsive-banner): banner responsivo que será utilizado na home e nas outras páginas

### DIFF
--- a/components/responsive-banner/ResponsiveBanner.tsx
+++ b/components/responsive-banner/ResponsiveBanner.tsx
@@ -1,0 +1,19 @@
+import type { Image as LiveImage } from "deco-sites/std/components/types.ts";
+
+export interface Props {
+  image?: {
+    src: LiveImage;
+  };
+}
+
+export default function ResponsiveBanner({ image }: Props) {
+  return (
+    <>
+      {image?.src && (
+        <div>
+          <img src={image?.src}></img>
+        </div>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## What is this contribution about?

Banner responsivo pensando em conjunto durante o planejamento, esse banner será utilizado em mais de uma página e foi definido que a altura da imagem ditará o tamanho do banner, dessa forma, é um componente muito simples que apenas irá receber uma imagem. 

## Extra info
Exemplo 1: Banner sendo chamado na home com uma dimensão de imagem X. 
<img width="1619" alt="image" src="https://github.com/deco-sites/shoppingbarra/assets/60283737/6af84408-c4ac-4ad3-9c19-3b8210769a7f">

Exemplo 2: Banner sendo chamado na página "Serviços"
<img width="1084" alt="image" src="https://github.com/deco-sites/shoppingbarra/assets/60283737/5a1c65c2-0a10-4b75-8413-4510dcc503b3">


Obs: Esse PR contém apenas o componente cru e não a chamada dele nas respectivas páginas, irei adiciona-lo conforme o desenvolvimento das próximas páginas

